### PR TITLE
Add EnrichAnything to Lead Generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@
 
 #### Lead Generation
 - [Optinmonster](http://optinmonster.com)
+- [EnrichAnything](https://www.enrichanything.com/)
 
 #### Sales
 - [Close.io](http://close.io/)


### PR DESCRIPTION
Adds EnrichAnything under Lead Generation. It fits as a niche lead-list builder that turns public hiring, ecommerce, and GTM signals into usable prospect lists.