### PR TITLE
Add Scrupp to Email Prospecting

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@
 - [Voila Norbert](https://www.voilanorbert.com/)
 - [Anymail Finder](https://anymailfinder.com/)
 - [Aeroleads](https://aeroleads.com/)
+- [Scrupp](https://scrupp.com) - Chrome extension for one-click verified email extraction from LinkedIn Sales Navigator, with CSV and Google Sheets export.
 
 #### Email Verification
 - [Kickbox](https://kickbox.com)


### PR DESCRIPTION
Adds [Scrupp](https://scrupp.com) to the **Email Prospecting** section.

Scrupp is a Chrome extension that extracts verified work emails and phone numbers from LinkedIn Sales Navigator searches in one click. Waterfall email verification across multiple providers delivers 95%+ deliverability. Native CSV and Google Sheets export, up to 2,500 leads per search.

Fits alongside Voila Norbert, Anymail Finder, and Aeroleads as a lead-data source for email prospecting.