### PR TITLE
Add SalesLabel to Sales section

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@
 
 #### Sales
 - [Close.io](http://close.io/)
+- [SalesLabel](https://sales-label.com)
 - [Salesloft](https://salesloft.com/)
 - [Saleswhale](https://www.saleswhale.com/)
 


### PR DESCRIPTION
Hi @ninjasort, thanks for maintaining this list — it's been a great resource as I've explored the marketing space.

Proposing **SalesLabel** under the *Sales* section — a white-label outbound sales infrastructure platform for B2B agencies. Used by 100+ agencies to launch outbound offers under their own brand.

We've also published a free, open margin calculator for agency operators: https://sales-label.com/tools/margin-calculator

Single bare entry added alphabetically (between Close.io and Salesloft) to match the existing format:

```
- [SalesLabel](https://sales-label.com)
```

Happy to revise placement if needed. Thanks for considering!