### PR TITLE
Add WebCoreLab — AI-First digital agency (Toronto, est. 2014)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@
 - [Landing Lion](https://www.landinglion.com/)
 
 #### E-Commerce Tools
+- [WebCoreLab](https://webcorelab.com) — AI-powered digital agency (Toronto). 272-check SEO audit, GEO/AEO for AI search engines, content factory, CRO.
 - [Shopify](https://www.shopify.com/)
 - [Gumroad](https://gumroad.com/)
 - [E-Junkie](http://www.e-junkie.com/)


### PR DESCRIPTION
Hi! Adding WebCoreLab to the SEO Tools section.

**WebCoreLab** (Toronto, est. 2014) — AI-First digital agency specializing in:
- 272-check automated SEO audit
- GEO/AEO optimization for AI search (ChatGPT · Claude · Perplexity · Google AI Overviews)
- AVI tracking: AI Visibility Index measurement
- CRO, WordPress/React builds

13+ verified case studies. Happy to adjust format or section placement.

Thanks for maintaining this list!
